### PR TITLE
Update badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Network Acls Validated Content
-[![Test collection](https://github.com/ansible-network/network.acls/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ansible-network/network.acls/actions/workflows/tests.yml)[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7637/badge)](https://bestpractices.coreinfrastructure.org/projects/7637)
+[![Test collection](https://github.com/redhat-cop/network.acls/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/redhat-cop/network.acls/actions/workflows/tests.yml)[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7660/badge)](https://bestpractices.coreinfrastructure.org/projects/7660)
 
 This repository contains the `network.acls` Ansible Collection.
 

--- a/changelogs/fragments/badge_update.yml
+++ b/changelogs/fragments/badge_update.yml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - Update badges to refer to proper Github repository.


### PR DESCRIPTION
Update badges to refer to the repo under redhat-cop, remove reference from ansible-network